### PR TITLE
refactor: Rename entity variables for replacement

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -2,12 +2,12 @@ import { ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 
-import { EntityService } from './services/entity.service';
+import { BriebugService } from './services/entity.service';
 
 @NgModule({
   imports: [CommonModule, HttpClientModule],
   declarations: [],
-  providers: [EntityService]
+  providers: [BriebugService]
 })
 export class CoreModule {
   constructor(

--- a/src/app/core/in-memory-data.service.ts
+++ b/src/app/core/in-memory-data.service.ts
@@ -1,12 +1,12 @@
-import { Entity } from '@state/entity/entity.model';
+import { Briebug } from '@state/entity/entity.model';
 
 export class InMemoryDataService {
   createDb() {
     const entities = [
-      { id: 1, name: 'Some Name', description: 'Some Description' } as Entity,
-      { id: 2, name: 'Better Name', description: 'Better Description' } as Entity,
-      { id: 3, name: 'Oh yeah? Well I have the best name!', description: 'And the best description, too!' } as Entity,
-      { id: 4, name: 'Well, agree to disagree, then.', description: 'And for the record, I disagree!' } as Entity
+      { id: 1, name: 'Some Name', description: 'Some Description' } as Briebug,
+      { id: 2, name: 'Better Name', description: 'Better Description' } as Briebug,
+      { id: 3, name: 'Oh yeah? Well I have the best name!', description: 'And the best description, too!' } as Briebug,
+      { id: 4, name: 'Well, agree to disagree, then.', description: 'And for the record, I disagree!' } as Briebug
     ];
 
     return { entities };

--- a/src/app/core/services/entity.service.ts
+++ b/src/app/core/services/entity.service.ts
@@ -3,39 +3,39 @@ import { HttpClient } from '@angular/common/http';
 
 import { Observable, of } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
-import { Entity } from '@state/entity/entity.model';
+import { Briebug } from '@state/entity/entity.model';
 
 @Injectable({
   providedIn: 'root'
 })
-export class EntityService {
+export class BriebugService {
   BASE_URL = 'api/';
 
   constructor(private httpClient: HttpClient) {}
 
-  create(entity: Entity): Observable<Entity> {
-    return this.httpClient.post<Entity>(`${this.BASE_URL}entities`, {
-      ...entity,
+  create(briebug: Briebug): Observable<Briebug> {
+    return this.httpClient.post<Briebug>(`${this.BASE_URL}entities`, {
+      ...briebug,
       // We clear out ID to indicate that this should be a new entry:
       id: null
     });
   }
 
-  search(): Observable<Array<Entity>> {
+  search(): Observable<Array<Briebug>> {
     // TODO: get based on state.paging (filter, sorting, page, limit)
-    return this.httpClient.get<Array<Entity>>(`${this.BASE_URL}entities`);
+    return this.httpClient.get<Array<Briebug>>(`${this.BASE_URL}entities`);
   }
 
-  getById(id: number): Observable<Entity> {
-    return this.httpClient.get<Entity>(`${this.BASE_URL}entities/${id}`);
+  getById(id: number): Observable<Briebug> {
+    return this.httpClient.get<Briebug>(`${this.BASE_URL}entities/${id}`);
   }
 
-  update(entity: Entity): Observable<Entity> {
+  update(briebug: Briebug): Observable<Briebug> {
     return this.httpClient
-      .put<Entity>(`${this.BASE_URL}entities/${entity.id}`, entity)
+      .put<Briebug>(`${this.BASE_URL}entities/${briebug.id}`, briebug)
       // The following pipe can be removed if your backend service returns the
       // edited value:
-      .pipe(switchMap(() => of(entity)));
+      .pipe(switchMap(() => of(briebug)));
   }
 
   deleteById(id: number): Observable<void> {

--- a/src/app/entities/components/entity-form/entity-form.component.spec.ts
+++ b/src/app/entities/components/entity-form/entity-form.component.spec.ts
@@ -1,22 +1,22 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { EntityFormComponent } from './entity-form.component';
+import { BriebugFormComponent } from './entity-form.component';
 import { ReactiveFormsModule } from '@angular/forms';
 
-describe('EntityFormComponent', () => {
-  let component: EntityFormComponent;
-  let fixture: ComponentFixture<EntityFormComponent>;
+describe('BreibugFormComponent', () => {
+  let component: BriebugFormComponent;
+  let fixture: ComponentFixture<BriebugFormComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [ ReactiveFormsModule ],
-      declarations: [ EntityFormComponent ]
+      declarations: [ BriebugFormComponent ]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(EntityFormComponent);
+    fixture = TestBed.createComponent(BriebugFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/entities/components/entity-form/entity-form.component.ts
+++ b/src/app/entities/components/entity-form/entity-form.component.ts
@@ -1,23 +1,33 @@
-import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, OnDestroy } from '@angular/core';
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnChanges,
+  SimpleChanges,
+  OnDestroy,
+  ChangeDetectionStrategy
+} from '@angular/core';
 
-import { Entity } from '@state/entity/entity.model';
+import { Briebug } from '@state/entity/entity.model';
 import { FormGroup, Validators, FormBuilder } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil, skip, debounceTime } from 'rxjs/operators';
 
 @Component({
-  selector: 'app-entity-form',
+  selector: 'app-briebug-form',
   templateUrl: './entity-form.component.html',
-  styleUrls: ['./entity-form.component.css']
+  styleUrls: ['./entity-form.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class EntityFormComponent implements OnChanges, OnDestroy {
+export class BriebugFormComponent implements OnChanges, OnDestroy {
   formGroup: FormGroup;
 
-  @Input() entity: Entity;
+  @Input() briebug: Briebug;
   @Input() disableFields: Boolean;
   @Input() showErrors: Boolean;
-  @Output() submit = new EventEmitter<Entity>();
-  @Output() entityChange = new EventEmitter<{ entity: Entity; valid: boolean }>();
+  @Output() submit = new EventEmitter<Briebug>();
+  @Output() briebugChanged = new EventEmitter<{ briebug: Briebug; valid: boolean }>();
 
   private destroyed$ = new Subject<void>();
 
@@ -26,8 +36,8 @@ export class EntityFormComponent implements OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.entity && changes.entity.currentValue) {
-      this.formGroup.patchValue(this.entity);
+    if (changes.briebug && changes.briebug.currentValue) {
+      this.formGroup.patchValue(this.briebug);
     }
   }
 
@@ -51,8 +61,8 @@ export class EntityFormComponent implements OnChanges, OnDestroy {
         debounceTime(500)
       )
       .subscribe((value) => {
-        this.entityChange.emit({
-          entity: value,
+        this.briebugChanged.emit({
+          briebug: value,
           valid: this.formGroup.valid
         });
       });

--- a/src/app/entities/containers/entity-list/entity-list.component.html
+++ b/src/app/entities/containers/entity-list/entity-list.component.html
@@ -4,10 +4,10 @@
 <p *ngIf="errorMessage$ | async" class="error-message">{{errorMessage$ | async}}</p>
 
 <ul>
-  <li *ngFor="let entity of entities$ | async">
-    <b>Name</b>: {{entity.name}}<br>
-    <b>Description</b>: {{entity.description}}<br>
-    <a [routerLink]="['/entities', entity.id]">(Edit)</a>
+  <li *ngFor="let briebug of briebugEntities$ | async">
+    <b>Name</b>: {{briebug.name}}<br>
+    <b>Description</b>: {{briebug.description}}<br>
+    <a [routerLink]="['/entities', briebug.id]">(Edit)</a>
   </li>
 </ul>
 

--- a/src/app/entities/containers/entity-list/entity-list.component.spec.ts
+++ b/src/app/entities/containers/entity-list/entity-list.component.spec.ts
@@ -1,17 +1,17 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { EntityListComponent } from './entity-list.component';
+import { BriebugListComponent } from './entity-list.component';
 import { StoreModule } from '@ngrx/store';
 import * as fromRoot from '@state/app.reducer';
 import { RouterTestingModule } from '@angular/router/testing';
 
-describe('EntityListComponent', () => {
-  let component: EntityListComponent;
-  let fixture: ComponentFixture<EntityListComponent>;
+describe('BriebugListComponent', () => {
+  let component: BriebugListComponent;
+  let fixture: ComponentFixture<BriebugListComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ EntityListComponent ],
+      declarations: [ BriebugListComponent ],
       imports: [
         RouterTestingModule,
         StoreModule.forRoot(fromRoot.appReducer)
@@ -21,7 +21,7 @@ describe('EntityListComponent', () => {
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(EntityListComponent);
+    fixture = TestBed.createComponent(BriebugListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/entities/containers/entity-list/entity-list.component.ts
+++ b/src/app/entities/containers/entity-list/entity-list.component.ts
@@ -4,26 +4,26 @@ import { select, Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { shareReplay } from 'rxjs/operators';
 
-import { getAllEntityEntities, getLoading, getError } from '@state/entity';
-import { State } from '@state/entity/entity.reducer';
-import { SearchAllEntityEntities } from '@state/entity/entity.actions';
-import { Entity } from '@state/entity/entity.model';
+import { getAllBriebugEntitiesAsArray, getLoading, getError } from '@state/entity';
+import { BriebugState } from '@state/entity/entity.reducer';
+import { SearchAllBriebugEntities } from '@state/entity/entity.actions';
+import { Briebug } from '@state/entity/entity.model';
 
 @Component({
   templateUrl: './entity-list.component.html',
   styleUrls: ['./entity-list.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class EntityListComponent implements OnInit {
-  entities$: Observable<Entity[]>;
+export class BriebugListComponent implements OnInit {
+  briebugEntities$: Observable<Array<Briebug>>;
   isLoading$: Observable<Boolean>;
   errorMessage$: Observable<String>;
 
-  constructor(private store: Store<State>) {}
+  constructor(private store: Store<BriebugState>) {}
 
   ngOnInit() {
-    this.store.dispatch(new SearchAllEntityEntities());
-    this.entities$ = this.store.pipe(select(getAllEntityEntities));
+    this.store.dispatch(new SearchAllBriebugEntities());
+    this.briebugEntities$ = this.store.pipe(select(getAllBriebugEntitiesAsArray));
     this.isLoading$ = this.store.pipe(select(getLoading));
     this.errorMessage$ = this.store.pipe(
       select(getError),

--- a/src/app/entities/containers/entity/entity.component.html
+++ b/src/app/entities/containers/entity/entity.component.html
@@ -3,12 +3,12 @@
 <p *ngIf="isLoading$ | async">Loading...</p>
 <p *ngIf="errorMessage$ | async" class="error-message">{{errorMessage$ | async}}</p>
 
-<app-entity-form
-  [entity]="entity$ | async"
+<app-briebug-form
+  [briebug]="briebug$ | async"
   [disableFields]="isLoading$ | async"
   [showErrors]="showFormErrors"
-  (entityChange)="onEntityChange($event)"
+  (briebugChanged)="onBriebugChanged($event)"
   (submit)="onSubmit($event)"
-></app-entity-form>
+></app-briebug-form>
 
 <a routerLink="/entities">Back to list</a>

--- a/src/app/entities/containers/entity/entity.component.spec.ts
+++ b/src/app/entities/containers/entity/entity.component.spec.ts
@@ -2,14 +2,14 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import * as fromRoot from '@state/app.reducer';
 import { StoreModule } from '@ngrx/store';
 
-import { EntityComponent } from './entity.component';
+import { BriebugComponent } from './entity.component';
 import { RouterTestingModule } from '@angular/router/testing';
-import { EntityFormComponent } from '../../components/entity-form/entity-form.component';
+import { BriebugFormComponent } from '../../components/entity-form/entity-form.component';
 import { ReactiveFormsModule } from '@angular/forms';
 
-describe('EntityComponent', () => {
-  let component: EntityComponent;
-  let fixture: ComponentFixture<EntityComponent>;
+describe('BriebugComponent', () => {
+  let component: BriebugComponent;
+  let fixture: ComponentFixture<BriebugComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -19,15 +19,15 @@ describe('EntityComponent', () => {
         StoreModule.forRoot(fromRoot.appReducer)
       ],
       declarations: [
-        EntityComponent,
-        EntityFormComponent
+        BriebugComponent,
+        BriebugFormComponent
       ]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(EntityComponent);
+    fixture = TestBed.createComponent(BriebugComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/entities/containers/entity/entity.component.ts
+++ b/src/app/entities/containers/entity/entity.component.ts
@@ -11,46 +11,48 @@ import {
   shareReplay
 } from 'rxjs/operators';
 
-import { getLoading, getSelectedEntity, getError } from '@state/entity';
-import { Entity } from '@state/entity/entity.model';
+import { getLoading, getSelectedBriebug, getError } from '@state/entity';
+import { Briebug } from '@state/entity/entity.model';
 import {
-  LoadEntityById,
-  InsertEntity,
-  UpdateEntity,
-  SelectEntityById
+  LoadBriebugById,
+  InsertBriebug,
+  UpdateBriebug,
+  SelectBriebugById
 } from '@state/entity/entity.actions';
-import { State } from '@state/entity/entity.reducer';
+import { BriebugState } from '@state/entity/entity.reducer';
 
 @Component({
   templateUrl: './entity.component.html',
   styleUrls: ['./entity.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class EntityComponent implements OnInit {
-  entity$: Observable<Entity>;
-  isLoading$: Observable<Boolean>;
-  valid: Boolean;
-  showFormErrors: Boolean;
-  entityEdits: Entity;
+export class BriebugComponent implements OnInit {
+  briebug$: Observable<Briebug>;
+  briebugEdits: Briebug;
   errorMessage$: Observable<String>;
+  isLoading$: Observable<Boolean>;
+  showFormErrors: Boolean;
+  valid: Boolean;
 
   constructor(
     private activatedRoute: ActivatedRoute,
-    private store: Store<State>
+    private store: Store<BriebugState>
   ) {}
 
   ngOnInit() {
-    this.entity$ = this.activatedRoute.paramMap.pipe(
+    this.briebug$ = this.activatedRoute.paramMap.pipe(
       filter((params) =>
         params.has('id') || this.activatedRoute.routeConfig.path === 'add'
       ),
       map((params) => params.get('id')),
       tap((id) => {
-        const EntityAction = id ? LoadEntityById : SelectEntityById;
-        this.store.dispatch(new EntityAction({ id: +id || null }));
+        const BriebugAction = id ? LoadBriebugById : SelectBriebugById;
+        this.store.dispatch(new BriebugAction({ id: +id || null }));
       }),
-      switchMap(() => this.store.pipe(select(getSelectedEntity))),
-      map((entity) => ({ ...entity }))
+      switchMap(() => this.store.pipe(select(getSelectedBriebug))),
+      map((briebug) => {
+        return { ...briebug };
+      })
     );
 
     // The following shareReplay calls allow us to use the async pipe multiple
@@ -69,8 +71,8 @@ export class EntityComponent implements OnInit {
     this.showFormErrors = false;
   }
 
-  onEntityChange({ entity, valid }: { entity: Entity; valid: Boolean }) {
-    this.entityEdits = entity;
+  onBriebugChanged({ briebug, valid }: { briebug: Briebug; valid: Boolean }) {
+    this.briebugEdits = briebug;
     this.valid = valid;
   }
 
@@ -81,7 +83,7 @@ export class EntityComponent implements OnInit {
       return;
     }
 
-    const EntityAction = this.entityEdits.id ? UpdateEntity : InsertEntity;
-    this.store.dispatch(new EntityAction({ entity: this.entityEdits }));
+    const BriebugAction = this.briebugEdits.id ? UpdateBriebug : InsertBriebug;
+    this.store.dispatch(new BriebugAction({ briebug: this.briebugEdits }));
   }
 }

--- a/src/app/entities/entities-routing.module.ts
+++ b/src/app/entities/entities-routing.module.ts
@@ -2,21 +2,21 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 import { EntitiesModule } from './entities.module';
-import { EntityListComponent } from './containers/entity-list/entity-list.component';
-import { EntityComponent } from './containers/entity/entity.component';
+import { BriebugListComponent } from './containers/entity-list/entity-list.component';
+import { BriebugComponent } from './containers/entity/entity.component';
 
 const routes: Routes = [
   {
     path: '',
-    component: EntityListComponent
+    component: BriebugListComponent
   },
   {
     path: 'add',
-    component: EntityComponent
+    component: BriebugComponent
   },
   {
     path: ':id',
-    component: EntityComponent
+    component: BriebugComponent
   }
 ];
 

--- a/src/app/entities/entities.module.ts
+++ b/src/app/entities/entities.module.ts
@@ -3,12 +3,12 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { EntityComponent } from './containers/entity/entity.component';
-import { EntityListComponent } from './containers/entity-list/entity-list.component';
-import { EntityFormComponent } from './components/entity-form/entity-form.component';
+import { BriebugComponent } from './containers/entity/entity.component';
+import { BriebugListComponent } from './containers/entity-list/entity-list.component';
+import { BriebugFormComponent } from './components/entity-form/entity-form.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, RouterModule],
-  declarations: [EntityListComponent, EntityComponent, EntityFormComponent]
+  declarations: [BriebugListComponent, BriebugComponent, BriebugFormComponent]
 })
 export class EntitiesModule {}

--- a/src/app/state/app.interfaces.ts
+++ b/src/app/state/app.interfaces.ts
@@ -1,10 +1,10 @@
 import { RouterReducerState } from '@ngrx/router-store';
 import { RouterStateUrl } from './state-utils';
-import { State as entityState } from './entity/entity.reducer';
+import { BriebugState } from './entity/entity.reducer';
 
 export interface AppState {
   router: RouterReducerState<RouterStateUrl>;
-  entity: entityState;
+  briebug: BriebugState;
 }
 
 export type State = AppState;

--- a/src/app/state/app.reducer.ts
+++ b/src/app/state/app.reducer.ts
@@ -5,10 +5,10 @@ import { storeFreeze } from 'ngrx-store-freeze';
 
 import { AppState } from './app.interfaces';
 import { environment } from '../../environments/environment';
-import { reducer as entityReducer } from './entity/entity.reducer';
+import { briebugReducer as briebugReducer } from './entity/entity.reducer';
 
 export const appReducer: ActionReducerMap<AppState> = {
-  entity: entityReducer,
+  briebug: briebugReducer,
   router: routerReducer
 };
 

--- a/src/app/state/entity/entity.actions.ts
+++ b/src/app/state/entity/entity.actions.ts
@@ -1,160 +1,160 @@
 import { Action } from '@ngrx/store';
 import { Update } from '@ngrx/entity';
-import { Entity } from './entity.model';
+import { Briebug } from './entity.model';
 
-export enum EntityActionTypes {
-  InsertEntity = '[Entity] Insert',
-  InsertEntitySuccess = '[Entity] Insert Success',
-  InsertEntityFail = '[Entity] Insert Fail',
+export enum BriebugActionTypes {
+  InsertBriebug = '[Briebug] Insert',
+  InsertBriebugSuccess = '[Briebug] Insert Success',
+  InsertBriebugFail = '[Briebug] Insert Fail',
 
-  SearchAllEntityEntities = '[Entity] Search',
-  SearchAllEntityEntitiesSuccess = '[Entity] Search Success',
-  SearchAllEntityEntitiesFail = '[Entity] Search Fail',
+  SearchAllBriebugEntities = '[Briebug] Search',
+  SearchAllBriebugEntitiesSuccess = '[Briebug] Search Success',
+  SearchAllBriebugEntitiesFail = '[Briebug] Search Fail',
 
-  LoadEntityById = '[Entity] Load By ID',
-  LoadEntityByIdSuccess = '[Entity] Load Success',
-  LoadEntityByIdFail = '[Entity] Load Fail',
+  LoadBriebugById = '[Briebug] Load By ID',
+  LoadBriebugByIdSuccess = '[Briebug] Load Success',
+  LoadBriebugByIdFail = '[Briebug] Load Fail',
 
-  UpdateEntity = '[Entity] Update',
-  UpdateEntitySuccess = '[Entity] Update Success',
-  UpdateEntityFail = '[Entity] Update Fail',
+  UpdateBriebug = '[Briebug] Update',
+  UpdateBriebugSuccess = '[Briebug] Update Success',
+  UpdateBriebugFail = '[Briebug] Update Fail',
 
-  DeleteEntityById = '[Entity] Delete By ID',
-  DeleteEntityByIdSuccess = '[Entity] Delete Success',
-  DeleteEntityByIdFail = '[Entity] Delete Fail',
+  DeleteBriebugById = '[Briebug] Delete By ID',
+  DeleteBriebugByIdSuccess = '[Briebug] Delete Success',
+  DeleteBriebugByIdFail = '[Briebug] Delete Fail',
 
-  SetEntityPaging = '[Entity] Set Paging',
-  SetEntityFilter = '[Entity] Set Filter',
-  SetEntitySorting = '[Entity] Set Sorting',
+  SetBriebugPaging = '[Briebug] Set Paging',
+  SetBriebugFilter = '[Briebug] Set Filter',
+  SetBriebugSorting = '[Briebug] Set Sorting',
 
-  SelectEntityById = '[Entity] Select By ID'
+  SelectBriebugById = '[Briebug] Select By ID'
 }
 
 // ========================================= INSERT
 
-export class InsertEntity implements Action {
-  readonly type = EntityActionTypes.InsertEntity;
-  constructor(public payload: { entity: Entity }) {}
+export class InsertBriebug implements Action {
+  readonly type = BriebugActionTypes.InsertBriebug;
+  constructor(public payload: { briebug: Briebug }) {}
 }
 
-export class InsertEntitySuccess implements Action {
-  readonly type = EntityActionTypes.InsertEntitySuccess;
-  constructor(public payload: { result: Entity }) {}
+export class InsertBriebugSuccess implements Action {
+  readonly type = BriebugActionTypes.InsertBriebugSuccess;
+  constructor(public payload: { result: Briebug }) {}
 }
 
-export class InsertEntityFail implements Action {
-  readonly type = EntityActionTypes.InsertEntityFail;
+export class InsertBriebugFail implements Action {
+  readonly type = BriebugActionTypes.InsertBriebugFail;
   constructor(public payload: { error: string }) {}
 }
 
 // ========================================= SEARCH
 
-export class SearchAllEntityEntities implements Action {
-  readonly type = EntityActionTypes.SearchAllEntityEntities;
+export class SearchAllBriebugEntities implements Action {
+  readonly type = BriebugActionTypes.SearchAllBriebugEntities;
 }
 
-export class SearchAllEntityEntitiesSuccess implements Action {
-  readonly type = EntityActionTypes.SearchAllEntityEntitiesSuccess;
-  constructor(public payload: { result: Entity[] }) {}
+export class SearchAllBriebugEntitiesSuccess implements Action {
+  readonly type = BriebugActionTypes.SearchAllBriebugEntitiesSuccess;
+  constructor(public payload: { result: Array<Briebug> }) {}
 }
 
-export class SearchAllEntityEntitiesFail implements Action {
-  readonly type = EntityActionTypes.SearchAllEntityEntitiesFail;
+export class SearchAllBriebugEntitiesFail implements Action {
+  readonly type = BriebugActionTypes.SearchAllBriebugEntitiesFail;
   constructor(public payload: { error: string }) {}
 }
 
 // ========================================= LOAD BY ID
 
-export class LoadEntityById implements Action {
-  readonly type = EntityActionTypes.LoadEntityById;
+export class LoadBriebugById implements Action {
+  readonly type = BriebugActionTypes.LoadBriebugById;
   constructor(public payload: { id: number }) {}
 }
 
-export class LoadEntityByIdSuccess implements Action {
-  readonly type = EntityActionTypes.LoadEntityByIdSuccess;
-  constructor(public payload: { result: Entity }) {}
+export class LoadBriebugByIdSuccess implements Action {
+  readonly type = BriebugActionTypes.LoadBriebugByIdSuccess;
+  constructor(public payload: { result: Briebug }) {}
 }
 
-export class LoadEntityByIdFail implements Action {
-  readonly type = EntityActionTypes.LoadEntityByIdFail;
+export class LoadBriebugByIdFail implements Action {
+  readonly type = BriebugActionTypes.LoadBriebugByIdFail;
   constructor(public payload: { error: string }) {}
 }
 
 // ========================================= UPDATE
 
-export class UpdateEntity implements Action {
-  readonly type = EntityActionTypes.UpdateEntity;
-  constructor(public payload: { entity: Entity }) {}
+export class UpdateBriebug implements Action {
+  readonly type = BriebugActionTypes.UpdateBriebug;
+  constructor(public payload: { briebug: Briebug }) {}
 }
 
-export class UpdateEntitySuccess implements Action {
-  readonly type = EntityActionTypes.UpdateEntitySuccess;
-  constructor(public payload: { update: Update<Entity> }) {}
+export class UpdateBriebugSuccess implements Action {
+  readonly type = BriebugActionTypes.UpdateBriebugSuccess;
+  constructor(public payload: { update: Update<Briebug> }) {}
 }
 
-export class UpdateEntityFail implements Action {
-  readonly type = EntityActionTypes.UpdateEntityFail;
+export class UpdateBriebugFail implements Action {
+  readonly type = BriebugActionTypes.UpdateBriebugFail;
   constructor(public payload: { error: string }) {}
 }
 
 // ========================================= DELETE
 
-export class DeleteEntityById implements Action {
-  readonly type = EntityActionTypes.DeleteEntityById;
+export class DeleteBriebugById implements Action {
+  readonly type = BriebugActionTypes.DeleteBriebugById;
   constructor(public payload: { id: number }) {}
 }
 
-export class DeleteEntityByIdSuccess implements Action {
-  readonly type = EntityActionTypes.DeleteEntityByIdSuccess;
-  constructor(public payload: { result: Entity }) {}
+export class DeleteBriebugByIdSuccess implements Action {
+  readonly type = BriebugActionTypes.DeleteBriebugByIdSuccess;
+  constructor(public payload: { result: Briebug }) {}
 }
 
-export class DeleteEntityByIdFail implements Action {
-  readonly type = EntityActionTypes.DeleteEntityByIdFail;
+export class DeleteBriebugByIdFail implements Action {
+  readonly type = BriebugActionTypes.DeleteBriebugByIdFail;
   constructor(public payload: { error: string }) {}
 }
 
 // ========================================= PAGING
 
-export class SetEntityPaging implements Action {
-  readonly type = EntityActionTypes.SetEntityPaging;
+export class SetBriebugPaging implements Action {
+  readonly type = BriebugActionTypes.SetBriebugPaging;
   constructor(public payload: { limit: number; page: number }) {}
 }
 
-export class SetEntityFilter implements Action {
-  readonly type = EntityActionTypes.SetEntityFilter;
+export class SetBriebugFilter implements Action {
+  readonly type = BriebugActionTypes.SetBriebugFilter;
   constructor(public payload: { filter: string; }) {}
 }
 
-export class SetEntitySorting implements Action {
-  readonly type = EntityActionTypes.SetEntitySorting;
+export class SetBriebugSorting implements Action {
+  readonly type = BriebugActionTypes.SetBriebugSorting;
   constructor(public payload: { sorting: string }) {}
 }
 
 // ========================================= SELECTED ID
 
-export class SelectEntityById implements Action {
-  readonly type = EntityActionTypes.SelectEntityById;
+export class SelectBriebugById implements Action {
+  readonly type = BriebugActionTypes.SelectBriebugById;
   constructor(public payload: { id: number }) {}
 }
 
-export type EntityActions =
-  | InsertEntity
-  | InsertEntitySuccess
-  | InsertEntityFail
-  | SearchAllEntityEntities
-  | SearchAllEntityEntitiesSuccess
-  | SearchAllEntityEntitiesFail
-  | LoadEntityById
-  | LoadEntityByIdSuccess
-  | LoadEntityByIdFail
-  | UpdateEntity
-  | UpdateEntitySuccess
-  | UpdateEntityFail
-  | DeleteEntityById
-  | DeleteEntityByIdSuccess
-  | DeleteEntityByIdFail
-  | SetEntityPaging
-  | SetEntityFilter
-  | SetEntitySorting
-  | SelectEntityById;
+export type BriebugActions =
+  | InsertBriebug
+  | InsertBriebugSuccess
+  | InsertBriebugFail
+  | SearchAllBriebugEntities
+  | SearchAllBriebugEntitiesSuccess
+  | SearchAllBriebugEntitiesFail
+  | LoadBriebugById
+  | LoadBriebugByIdSuccess
+  | LoadBriebugByIdFail
+  | UpdateBriebug
+  | UpdateBriebugSuccess
+  | UpdateBriebugFail
+  | DeleteBriebugById
+  | DeleteBriebugByIdSuccess
+  | DeleteBriebugByIdFail
+  | SetBriebugPaging
+  | SetBriebugFilter
+  | SetBriebugSorting
+  | SelectBriebugById;

--- a/src/app/state/entity/entity.effects.ts
+++ b/src/app/state/entity/entity.effects.ts
@@ -13,43 +13,43 @@ import { Action } from '@ngrx/store';
 import { Update } from '@ngrx/entity';
 
 import {
-  EntityActionTypes,
-  InsertEntity,
-  InsertEntitySuccess,
-  InsertEntityFail,
-  SearchAllEntityEntities,
-  SearchAllEntityEntitiesSuccess,
-  SearchAllEntityEntitiesFail,
-  LoadEntityById,
-  LoadEntityByIdSuccess,
-  LoadEntityByIdFail,
-  UpdateEntity,
-  UpdateEntitySuccess,
-  UpdateEntityFail,
-  DeleteEntityById,
-  DeleteEntityByIdSuccess,
-  DeleteEntityByIdFail,
-  SetEntityPaging,
-  SetEntityFilter,
-  SetEntitySorting,
-  SelectEntityById
+  BriebugActionTypes,
+  InsertBriebug,
+  InsertBriebugSuccess,
+  InsertBriebugFail,
+  SearchAllBriebugEntities,
+  SearchAllBriebugEntitiesSuccess,
+  SearchAllBriebugEntitiesFail,
+  LoadBriebugById,
+  LoadBriebugByIdSuccess,
+  LoadBriebugByIdFail,
+  UpdateBriebug,
+  UpdateBriebugSuccess,
+  UpdateBriebugFail,
+  DeleteBriebugById,
+  DeleteBriebugByIdSuccess,
+  DeleteBriebugByIdFail,
+  SetBriebugPaging,
+  SetBriebugFilter,
+  SetBriebugSorting,
+  SelectBriebugById
 } from './entity.actions';
-import { Entity } from './entity.model';
-import { EntityService } from '@core/services/entity.service';
+import { Briebug } from './entity.model';
+import { BriebugService } from '@core/services/entity.service';
 
 @Injectable()
-export class EntityEffects {
+export class BriebugEffects {
   // ========================================= INSERT
 
   @Effect()
   insert: Observable<Action> = this.actions$
-    .ofType<InsertEntity>(EntityActionTypes.InsertEntity)
+    .ofType<InsertBriebug>(BriebugActionTypes.InsertBriebug)
     .pipe(
       exhaustMap((action) =>
-        this.service.create(action.payload.entity).pipe(
-          map((entity: Entity) => new InsertEntitySuccess({ result: entity })),
+        this.service.create(action.payload.briebug).pipe(
+          map((briebug: Briebug) => new InsertBriebugSuccess({ result: briebug })),
           catchError(({ message }) =>
-            of(new InsertEntityFail({ error: message }))
+            of(new InsertBriebugFail({ error: message }))
           )
         )
       )
@@ -60,7 +60,7 @@ export class EntityEffects {
     dispatch: false
   })
   insertSuccess: Observable<Action> = this.actions$
-    .ofType<InsertEntitySuccess>(EntityActionTypes.InsertEntitySuccess)
+    .ofType<InsertBriebugSuccess>(BriebugActionTypes.InsertBriebugSuccess)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.result
@@ -72,7 +72,7 @@ export class EntityEffects {
     dispatch: false
   })
   insertFail: Observable<Action> = this.actions$
-    .ofType<InsertEntityFail>(EntityActionTypes.InsertEntityFail)
+    .ofType<InsertBriebugFail>(BriebugActionTypes.InsertBriebugFail)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.error
@@ -83,17 +83,17 @@ export class EntityEffects {
 
   @Effect()
   search: Observable<Action> = this.actions$
-    .ofType<SearchAllEntityEntities>(EntityActionTypes.SearchAllEntityEntities)
+    .ofType<SearchAllBriebugEntities>(BriebugActionTypes.SearchAllBriebugEntities)
     .pipe(
       // Use the state's filtering and pagination values in this search call
       // here if desired:
       exhaustMap((action) =>
         this.service.search().pipe(
-          map((entities: Entity[]) =>
-            new SearchAllEntityEntitiesSuccess({ result: entities })
+          map((entities: Array<Briebug>) =>
+            new SearchAllBriebugEntitiesSuccess({ result: entities })
           ),
           catchError(({ message }) =>
-            of(new SearchAllEntityEntitiesFail({ error: message }))
+            of(new SearchAllBriebugEntitiesFail({ error: message }))
           )
         )
       )
@@ -104,7 +104,7 @@ export class EntityEffects {
     dispatch: false
   })
   searchSuccess: Observable<Action> = this.actions$
-    .ofType<SearchAllEntityEntitiesSuccess>(EntityActionTypes.SearchAllEntityEntitiesSuccess)
+    .ofType<SearchAllBriebugEntitiesSuccess>(BriebugActionTypes.SearchAllBriebugEntitiesSuccess)
     .pipe(
       tap((entities) => {
         // do stuff with action.payload.result
@@ -116,7 +116,7 @@ export class EntityEffects {
     dispatch: false
   })
   searchFail: Observable<Action> = this.actions$
-    .ofType<SearchAllEntityEntitiesFail>(EntityActionTypes.SearchAllEntityEntitiesFail)
+    .ofType<SearchAllBriebugEntitiesFail>(BriebugActionTypes.SearchAllBriebugEntitiesFail)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.error
@@ -127,14 +127,14 @@ export class EntityEffects {
 
   @Effect()
   loadById: Observable<Action> = this.actions$
-    .ofType<LoadEntityById>(EntityActionTypes.LoadEntityById)
+    .ofType<LoadBriebugById>(BriebugActionTypes.LoadBriebugById)
     .pipe(
       switchMap((action) =>
         this.service.getById(action.payload.id).pipe(
-          map((entity: Entity) => new LoadEntityByIdSuccess({ result: entity })
+          map((briebug: Briebug) => new LoadBriebugByIdSuccess({ result: briebug })
           ),
           catchError(({ message }) =>
-            of(new LoadEntityByIdFail({ error: message }))
+            of(new LoadBriebugByIdFail({ error: message }))
           )
         )
       )
@@ -145,7 +145,7 @@ export class EntityEffects {
     dispatch: false
   })
   loadByIdSuccess: Observable<Action> = this.actions$
-    .ofType<LoadEntityByIdSuccess>(EntityActionTypes.LoadEntityByIdSuccess)
+    .ofType<LoadBriebugByIdSuccess>(BriebugActionTypes.LoadBriebugByIdSuccess)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.result
@@ -157,7 +157,7 @@ export class EntityEffects {
     dispatch: false
   })
   loadByIdFail: Observable<Action> = this.actions$
-    .ofType<LoadEntityByIdFail>(EntityActionTypes.LoadEntityByIdFail)
+    .ofType<LoadBriebugByIdFail>(BriebugActionTypes.LoadBriebugByIdFail)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.error
@@ -168,20 +168,20 @@ export class EntityEffects {
 
   @Effect()
   update: Observable<Action> = this.actions$
-    .ofType<UpdateEntity>(EntityActionTypes.UpdateEntity)
+    .ofType<UpdateBriebug>(BriebugActionTypes.UpdateBriebug)
     .pipe(
       exhaustMap((action) =>
-        this.service.update(action.payload.entity).pipe(
-          map((entity: Entity) =>
-            new UpdateEntitySuccess({
+        this.service.update(action.payload.briebug).pipe(
+          map((briebug: Briebug) =>
+            new UpdateBriebugSuccess({
               update: {
-                id: entity.id,
-                changes: entity
-              } as Update<Entity>
+                id: briebug.id,
+                changes: briebug
+              } as Update<Briebug>
             })
           ),
           catchError(({ message }) =>
-            of(new UpdateEntityFail({ error: message }))
+            of(new UpdateBriebugFail({ error: message }))
           )
         )
       )
@@ -192,7 +192,7 @@ export class EntityEffects {
     dispatch: false
   })
   updateSuccess: Observable<Action> = this.actions$
-    .ofType<UpdateEntitySuccess>(EntityActionTypes.UpdateEntitySuccess)
+    .ofType<UpdateBriebugSuccess>(BriebugActionTypes.UpdateBriebugSuccess)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.result
@@ -204,7 +204,7 @@ export class EntityEffects {
     dispatch: false
   })
   updateFail: Observable<Action> = this.actions$
-    .ofType<UpdateEntityFail>(EntityActionTypes.UpdateEntityFail)
+    .ofType<UpdateBriebugFail>(BriebugActionTypes.UpdateBriebugFail)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.error
@@ -215,13 +215,13 @@ export class EntityEffects {
 
   @Effect()
   delete: Observable<Action> = this.actions$
-    .ofType<DeleteEntityById>(EntityActionTypes.DeleteEntityById)
+    .ofType<DeleteBriebugById>(BriebugActionTypes.DeleteBriebugById)
     .pipe(
       exhaustMap((action) =>
         this.service.deleteById(action.payload.id).pipe(
-          map((entity: Entity) => new DeleteEntityByIdSuccess({ result: entity })),
+          map((briebug: Briebug) => new DeleteBriebugByIdSuccess({ result: briebug })),
           catchError(({ message }) =>
-            of(new DeleteEntityByIdFail({ error: message }))
+            of(new DeleteBriebugByIdFail({ error: message }))
           )
         )
       )
@@ -232,7 +232,7 @@ export class EntityEffects {
     dispatch: false
   })
   deleteSuccess: Observable<Action> = this.actions$
-    .ofType<UpdateEntitySuccess>(EntityActionTypes.UpdateEntitySuccess)
+    .ofType<UpdateBriebugSuccess>(BriebugActionTypes.UpdateBriebugSuccess)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.result
@@ -244,7 +244,7 @@ export class EntityEffects {
     dispatch: false
   })
   deleteFail: Observable<Action> = this.actions$
-    .ofType<DeleteEntityByIdFail>(EntityActionTypes.DeleteEntityByIdFail)
+    .ofType<DeleteBriebugByIdFail>(BriebugActionTypes.DeleteBriebugByIdFail)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.error
@@ -257,7 +257,7 @@ export class EntityEffects {
     dispatch: false
   })
   paging: Observable<Action> = this.actions$
-    .ofType<SetEntityPaging>(EntityActionTypes.SetEntityPaging)
+    .ofType<SetBriebugPaging>(BriebugActionTypes.SetBriebugPaging)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.limit & action.payload.page
@@ -268,7 +268,7 @@ export class EntityEffects {
     dispatch: false
   })
   filter: Observable<Action> = this.actions$
-    .ofType<SetEntityFilter>(EntityActionTypes.SetEntityFilter)
+    .ofType<SetBriebugFilter>(BriebugActionTypes.SetBriebugFilter)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.filter
@@ -279,7 +279,7 @@ export class EntityEffects {
     dispatch: false
   })
   sorting: Observable<Action> = this.actions$
-    .ofType<SetEntitySorting>(EntityActionTypes.SetEntitySorting)
+    .ofType<SetBriebugSorting>(BriebugActionTypes.SetBriebugSorting)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.sorting
@@ -292,12 +292,12 @@ export class EntityEffects {
     dispatch: false
   })
   selectedId: Observable<Action> = this.actions$
-    .ofType<SelectEntityById>(EntityActionTypes.SelectEntityById)
+    .ofType<SelectBriebugById>(BriebugActionTypes.SelectBriebugById)
     .pipe(
       tap((action) => {
         // do stuff with: action.payload.id
       })
     );
 
-  constructor(private actions$: Actions, private service: EntityService) {}
+  constructor(private actions$: Actions, private service: BriebugService) {}
 }

--- a/src/app/state/entity/entity.model.ts
+++ b/src/app/state/entity/entity.model.ts
@@ -1,4 +1,4 @@
-export interface Entity {
+export interface Briebug {
   id: number;
   name: string;
   description: string;

--- a/src/app/state/entity/entity.reducer.ts
+++ b/src/app/state/entity/entity.reducer.ts
@@ -1,8 +1,8 @@
 import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
-import { Entity } from './entity.model';
-import { EntityActions, EntityActionTypes } from './entity.actions';
+import { Briebug } from './entity.model';
+import { BriebugActions, BriebugActionTypes } from './entity.actions';
 
-export interface State extends EntityState<Entity> {
+export interface BriebugState extends EntityState<Briebug> {
   // additional entities state properties
   selectedId: number;
   loading: boolean;
@@ -15,10 +15,10 @@ export interface State extends EntityState<Entity> {
   };
 }
 
-export const adapter: EntityAdapter<Entity> = createEntityAdapter<Entity>();
+export const adapter: EntityAdapter<Briebug> = createEntityAdapter<Briebug>();
 
-export const initialState: State = adapter.getInitialState({
-  // additional entity state properties
+export const initialState: BriebugState = adapter.getInitialState({
+  // additional briebug state properties
   selectedId: null,
   loading: false,
   error: '',
@@ -30,93 +30,93 @@ export const initialState: State = adapter.getInitialState({
   }
 });
 
-export function reducer(state = initialState, action: EntityActions): State {
+export function briebugReducer(state = initialState, action: BriebugActions): BriebugState {
   switch (action.type) {
-    case EntityActionTypes.InsertEntity:
+    case BriebugActionTypes.InsertBriebug:
       return {
         ...state,
         loading: true,
         error: ''
       };
 
-    case EntityActionTypes.InsertEntitySuccess:
+    case BriebugActionTypes.InsertBriebugSuccess:
       return {
         ...adapter.addOne(action.payload.result, state),
         loading: false
       };
 
-    case EntityActionTypes.InsertEntityFail:
+    case BriebugActionTypes.InsertBriebugFail:
       return {
         ...state,
         loading: false,
-        error: 'Entity insert failed: ' + action.payload.error
+        error: 'Briebug insert failed: ' + action.payload.error
       };
 
-    case EntityActionTypes.SearchAllEntityEntities:
+    case BriebugActionTypes.SearchAllBriebugEntities:
       return {
         ...adapter.removeAll(state),
         loading: true,
         error: ''
       };
 
-    case EntityActionTypes.LoadEntityById:
-      return {
-        ...adapter.removeAll(state),
-        selectedId: action.payload.id,
-        loading: true,
-        error: ''
-      };
-
-    case EntityActionTypes.SearchAllEntityEntitiesSuccess:
+    case BriebugActionTypes.SearchAllBriebugEntitiesSuccess:
       return {
         ...adapter.addAll(action.payload.result, state),
         loading: false,
         error: ''
       };
 
-    case EntityActionTypes.SearchAllEntityEntitiesFail:
+    case BriebugActionTypes.SearchAllBriebugEntitiesFail:
       return {
         ...state,
         loading: false,
-        error: 'Entity search failed: ' + action.payload.error
+        error: 'Briebug search failed: ' + action.payload.error
       };
 
-    case EntityActionTypes.LoadEntityByIdSuccess:
+    case BriebugActionTypes.LoadBriebugById:
+      return {
+        ...adapter.removeAll(state),
+        selectedId: action.payload.id,
+        loading: true,
+        error: ''
+      };
+
+    case BriebugActionTypes.LoadBriebugByIdSuccess:
       return {
         ...adapter.addOne(action.payload.result, state),
         loading: false,
         error: ''
       };
 
-    case EntityActionTypes.LoadEntityByIdFail:
+    case BriebugActionTypes.LoadBriebugByIdFail:
       return {
         ...state,
         loading: false,
-        error: 'Entity load failed: ' + action.payload.error
+        error: 'Briebug load failed: ' + action.payload.error
       };
 
-    case EntityActionTypes.UpdateEntity:
+    case BriebugActionTypes.UpdateBriebug:
       return {
         ...state,
         loading: true,
         error: ''
       };
 
-    case EntityActionTypes.UpdateEntitySuccess:
+    case BriebugActionTypes.UpdateBriebugSuccess:
       return {
         ...adapter.updateOne(action.payload.update, state),
         loading: false,
         error: ''
       };
 
-    case EntityActionTypes.UpdateEntityFail:
+    case BriebugActionTypes.UpdateBriebugFail:
       return {
         ...state,
         loading: false,
-        error: 'Entity update failed: ' + action.payload.error
+        error: 'Briebug update failed: ' + action.payload.error
       };
 
-    case EntityActionTypes.DeleteEntityById:
+    case BriebugActionTypes.DeleteBriebugById:
       return {
         ...state,
         selectedId: action.payload.id,
@@ -124,23 +124,23 @@ export function reducer(state = initialState, action: EntityActions): State {
         error: ''
       };
 
-    case EntityActionTypes.DeleteEntityByIdSuccess:
+    case BriebugActionTypes.DeleteBriebugByIdSuccess:
       return {
         ...adapter.removeOne(action.payload.result.id, state),
         loading: false,
         error: ''
       };
 
-    case EntityActionTypes.DeleteEntityByIdFail:
+    case BriebugActionTypes.DeleteBriebugByIdFail:
       return {
         ...state,
         loading: false,
-        error: 'Entity delete failed: ' + action.payload.error
+        error: 'Briebug delete failed: ' + action.payload.error
       };
 
-    case EntityActionTypes.SetEntityPaging:
-    case EntityActionTypes.SetEntityFilter:
-    case EntityActionTypes.SetEntitySorting:
+    case BriebugActionTypes.SetBriebugPaging:
+    case BriebugActionTypes.SetBriebugFilter:
+    case BriebugActionTypes.SetBriebugSorting:
       return {
         ...state,
         paging: {
@@ -149,7 +149,7 @@ export function reducer(state = initialState, action: EntityActions): State {
         }
       };
 
-    case EntityActionTypes.SelectEntityById:
+    case BriebugActionTypes.SelectBriebugById:
       return {
         ...state,
         selectedId: action.payload.id,
@@ -161,7 +161,7 @@ export function reducer(state = initialState, action: EntityActions): State {
   }
 }
 
-export const getSelectedId = (state: State) => state.selectedId;
-export const getLoading = (state: State) => state.loading;
-export const getError = (state: State) => state.error;
-export const getPaging = (state: State) => state.paging;
+export const getSelectedId = (state: BriebugState) => state.selectedId;
+export const getLoading = (state: BriebugState) => state.loading;
+export const getError = (state: BriebugState) => state.error;
+export const getPaging = (state: BriebugState) => state.paging;

--- a/src/app/state/entity/index.ts
+++ b/src/app/state/entity/index.ts
@@ -1,39 +1,40 @@
 import { createSelector, createFeatureSelector } from '@ngrx/store';
 
-import * as fromEntity from './entity.reducer';
-import { State as EntityState } from './entity.reducer';
+import * as fromBriebugState from './entity.reducer';
+import { BriebugState } from './entity.reducer';
 
-export const getEntityState = createFeatureSelector<EntityState>('entity');
+export const getBriebugState = createFeatureSelector<BriebugState>('briebug');
 
 export const {
-  selectIds: getEntityIds,
-  selectEntities: getEntityEntities,
-  selectAll: getAllEntityEntities,
-  selectTotal: getTotalEntityEntities
-} = fromEntity.adapter.getSelectors(getEntityState);
+  selectIds: getAllBriebugIds,
+  selectEntities: getAllBriebugEntitiesAsMap,
+  selectAll: getAllBriebugEntitiesAsArray,
+  selectTotal: getTotalBriebugEntities
+} = fromBriebugState.adapter.getSelectors(getBriebugState);
 
-export const getSelectedEntityId = createSelector(
-  getEntityState,
-  fromEntity.getSelectedId
+export const getSelectedBriebugId = createSelector(
+  getBriebugState,
+  fromBriebugState.getSelectedId
 );
 
-export const getSelectedEntity = createSelector(
-  getSelectedEntityId,
-  getEntityEntities,
-  (selectedEntityId, entities) => selectedEntityId && entities[selectedEntityId]
+export const getSelectedBriebug = createSelector(
+  getSelectedBriebugId,
+  getAllBriebugEntitiesAsMap,
+  (selectedBriebugId, briebugEntities) =>
+    selectedBriebugId && briebugEntities[selectedBriebugId]
 );
 
 export const getLoading = createSelector(
-  getEntityState,
-  fromEntity.getLoading
+  getBriebugState,
+  fromBriebugState.getLoading
 );
 
 export const getError = createSelector(
-  getEntityState,
-  fromEntity.getError
+  getBriebugState,
+  fromBriebugState.getError
 );
 
 export const getPaging = createSelector(
-  getEntityState,
-  fromEntity.getPaging
+  getBriebugState,
+  fromBriebugState.getPaging
 );

--- a/src/app/state/state.module.ts
+++ b/src/app/state/state.module.ts
@@ -9,14 +9,14 @@ import { StoreModule } from '@ngrx/store';
 import { appMetaReducers, appReducer } from './app.reducer';
 import { CustomRouterStateSerializer } from './state-utils';
 import { environment } from '../../environments/environment';
-import { EntityEffects } from '@state/entity/entity.effects';
+import { BriebugEffects } from '@state/entity/entity.effects';
 
 @NgModule({
   imports: [
     CommonModule,
     StoreRouterConnectingModule,
     StoreModule.forRoot(appReducer, { metaReducers: appMetaReducers }),
-    EffectsModule.forRoot([EntityEffects]),
+    EffectsModule.forRoot([BriebugEffects]),
     !environment.production ? StoreDevtoolsModule.instrument() : []
   ],
   declarations: []

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>NgrxEntityGenerator</title>
+  <title>NGRX Entity Generator Example App</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
All instances of "Briebug" and "briebug" will be replaced with the
schematic <%= ... %> syntax when copied to the schematic directory